### PR TITLE
BUG : Swagger2 에서 Controller 경로를 인식하지 못하는 오류

### DIFF
--- a/src/main/java/dev/riyenas/osam/config/SwaggerConfig.java
+++ b/src/main/java/dev/riyenas/osam/config/SwaggerConfig.java
@@ -1,6 +1,5 @@
 package dev.riyenas.osam.config;
 
-import com.google.common.base.Predicates;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;
@@ -15,7 +14,10 @@ public class SwaggerConfig {
     @Bean
     public Docket api(){
         return new Docket(DocumentationType.SWAGGER_2).select()
-                .apis(Predicates.not(RequestHandlerSelectors.basePackage("dev.riyenas.osam.")))
-                .paths(PathSelectors.any()).build();
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+
+
     }
 }


### PR DESCRIPTION
* API의 경로를 RequestHandlerSelectors.any()로 변경

```
return new Docket(DocumentationType.SWAGGER_2).select()
            .apis(RequestHandlerSelectors.any())
            .paths(PathSelectors.any())
            .build();
```

Resolves #16