### PR TITLE
ENH : Time-based OTP 기능 구현

### DIFF
--- a/src/main/java/dev/riyenas/osam/domain/auth/CryptoType.java
+++ b/src/main/java/dev/riyenas/osam/domain/auth/CryptoType.java
@@ -1,0 +1,17 @@
+package dev.riyenas.osam.domain.auth;
+
+public enum CryptoType {
+    HmacSHA1("HmacSHA1"),
+    HmacSHA256("HmacSHA1"),
+    HmacSHA512("HmacSHA1");
+
+    CryptoType(String crypto) {
+        this.crypto = crypto;
+    }
+
+    private final String crypto;
+
+    public String toString() {
+        return crypto;
+    }
+}

--- a/src/main/java/dev/riyenas/osam/domain/auth/TimeBasedOTP.java
+++ b/src/main/java/dev/riyenas/osam/domain/auth/TimeBasedOTP.java
@@ -1,0 +1,95 @@
+package dev.riyenas.osam.domain.auth;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+
+public class TimeBasedOTP {
+
+    private TimeBasedOTP() {}
+
+    private static final int[] DIGITS_POWER = {1,10,100,1000,10000,100000,1000000,10000000,100000000};
+
+    private static byte[] hmac_sha1(String crypto, byte[] keyBytes, byte[] text) {
+        try {
+            Mac hmac;
+            hmac = Mac.getInstance(crypto);
+            SecretKeySpec macKey =
+                    new SecretKeySpec(keyBytes, "RAW");
+            hmac.init(macKey);
+            return hmac.doFinal(text);
+        } catch (GeneralSecurityException gse) {
+            throw new UndeclaredThrowableException(gse);
+        }
+    }
+
+    private static byte[] hexStrToBytes(String hex) {
+        byte[] bArray = new BigInteger("10" + hex, 16).toByteArray();
+
+        byte[] ret = new byte[bArray.length - 1];
+
+        for (int i = 0; i < ret.length ; i++)
+            ret[i] = bArray[i+1];
+
+        return ret;
+    }
+
+    public static String calcSteps(Long time, Long T0, Long X) {
+        long T = (time - T0) / X;
+
+        String steps = "0";
+        steps = Long.toHexString(T).toUpperCase();
+
+        while (steps.length() < 16) {
+            steps = "0" + steps;
+        }
+
+        return steps;
+    }
+
+    public static String generateTOTP(String key, String time, String returnDigits) {
+        return generateTOTP(key, time, returnDigits, CryptoType.HmacSHA1.toString());
+    }
+
+    public static String generateTOTP256(String key, String time, String returnDigits) {
+        return generateTOTP(key, time, returnDigits, CryptoType.HmacSHA256.toString());
+    }
+
+    public static String generateTOTP512(String key, String time, String returnDigits) {
+        return generateTOTP(key, time, returnDigits, CryptoType.HmacSHA512.toString());
+    }
+
+    public static String generateTOTP(String key, String time, String returnDigits, String crypto) {
+        int codeDigits = Integer.decode(returnDigits).intValue();
+        String result = null;
+        byte[] hash;
+
+        while(time.length() < 16 ) {
+            time = "0" + time;
+        }
+
+        byte[] msg = hexStrToBytes(time);
+        byte[] k = hexStrToBytes(key);
+
+        hash = hmac_sha1(crypto, k, msg);
+
+        int offset = hash[hash.length - 1] & 0xf;
+
+        int binary = ((hash[offset] & 0x7f) << 24) |
+                ((hash[offset + 1] & 0xff) << 16) |
+                ((hash[offset + 2] & 0xff) << 8) |
+                (hash[offset + 3] & 0xff);
+
+        int otp = binary % DIGITS_POWER[codeDigits];
+
+        result = Integer.toString(otp);
+
+        while (result.length() < codeDigits) {
+            result = "0" + result;
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/dev/riyenas/osam/service/TimeBasedOTPAuthService.java
+++ b/src/main/java/dev/riyenas/osam/service/TimeBasedOTPAuthService.java
@@ -1,0 +1,33 @@
+package dev.riyenas.osam.service;
+
+import dev.riyenas.osam.domain.auth.CryptoType;
+import dev.riyenas.osam.domain.auth.TimeBasedOTP;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.Calendar;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class TimeBasedOTPAuthService {
+
+    public String generateByCurrentTime(String seed) {
+
+        Calendar time = Calendar.getInstance();
+
+        String steps = TimeBasedOTP.calcSteps(time.getTimeInMillis() / 1000, 0L, 10L);
+
+        log.info(time.getTime().toString());
+
+        return TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512.toString());
+    }
+
+    public String generateBySeedAndTimeInMills(String seed, Long timeInMillis) {
+
+        String steps = TimeBasedOTP.calcSteps(timeInMillis / 1000, 0L, 10L);
+
+        return TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512.toString());
+    }
+}

--- a/src/main/java/dev/riyenas/osam/web/APITimeBasedOTPAuthController.java
+++ b/src/main/java/dev/riyenas/osam/web/APITimeBasedOTPAuthController.java
@@ -1,0 +1,25 @@
+package dev.riyenas.osam.web;
+
+import dev.riyenas.osam.service.TimeBasedOTPAuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.web.bind.annotation.*;
+
+@Log4j2
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth/totp/")
+public class APITimeBasedOTPAuthController {
+
+    private final TimeBasedOTPAuthService timeBasedOTPAuthService;
+
+    @GetMapping("generate")
+    public String generate(@RequestParam String seed, @RequestParam Long timeInMillis) {
+        return timeBasedOTPAuthService.generateBySeedAndTimeInMills(seed, timeInMillis);
+    }
+
+    @GetMapping("generate/seed/{seed}")
+    public String generate(@PathVariable String seed) {
+        return timeBasedOTPAuthService.generateByCurrentTime(seed);
+    }
+}

--- a/src/test/java/dev/riyenas/osam/totp/TimeBasedOTPTest.java
+++ b/src/test/java/dev/riyenas/osam/totp/TimeBasedOTPTest.java
@@ -1,0 +1,33 @@
+package dev.riyenas.osam.totp;
+
+import dev.riyenas.osam.domain.auth.CryptoType;
+import dev.riyenas.osam.domain.auth.TimeBasedOTP;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TimeBasedOTPTest {
+    private static final Logger log = LoggerFactory.getLogger(TimeBasedOTPTest.class);
+
+    @Test
+    public void createTimeBasedOTP() {
+        String seed = "0123456789012345678901234567890123456789";
+        long T0 = 0;
+        long X = 10;
+        long testTime = 100;
+
+        String stepsA = TimeBasedOTP.calcSteps(testTime, T0, X);
+        String timeBasedOTPA = TimeBasedOTP.generateTOTP(seed, stepsA, "8", CryptoType.HmacSHA512.toString());
+
+        String stepsB = TimeBasedOTP.calcSteps(testTime + 9, T0, X);
+        String timeBasedOTPB = TimeBasedOTP.generateTOTP(seed, stepsB, "8", CryptoType.HmacSHA512.toString());
+
+        Assertions.assertEquals(timeBasedOTPA, timeBasedOTPB);
+    }
+}


### PR DESCRIPTION
* 앱에서 네트워크 연결 없이 인증을 진행할수 있도록 하기 위해 TOTP를 사용
* seed는 Soldier entity에 UUID로 사용하기로 한 40자리 숫자로 이용
* otp 유지 시간은 10초로 설정

Resolves #18