### PR TITLE
ENH : 스캔한 QR코드의 Time-basedOTP값 검증 기능 구현

### DIFF
--- a/src/main/java/dev/riyenas/osam/service/TimeBasedOTPService.java
+++ b/src/main/java/dev/riyenas/osam/service/TimeBasedOTPService.java
@@ -2,6 +2,8 @@ package dev.riyenas.osam.service;
 
 import dev.riyenas.osam.domain.auth.CryptoType;
 import dev.riyenas.osam.domain.auth.TimeBasedOTP;
+import dev.riyenas.osam.domain.device.Device;
+import dev.riyenas.osam.domain.device.DeviceRepository;
 import dev.riyenas.osam.web.dto.iot.TOTPValidRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -13,6 +15,8 @@ import java.util.Calendar;
 @Service
 @RequiredArgsConstructor
 public class TimeBasedOTPService {
+
+    private final DeviceRepository deviceRepository;
 
     public String generateByCurrentTime(String seed) {
 
@@ -34,11 +38,13 @@ public class TimeBasedOTPService {
 
         String steps = TimeBasedOTP.calcSteps(dto.getTimeInMillis() / 1000, 0L, 10L);
 
-        String resultTOTP = TimeBasedOTP.generateTOTP(dto.getSeed(), steps, "8", CryptoType.HmacSHA512.toString());
+        Device device = deviceRepository.findById(dto.getDeviceId()).orElseThrow(() ->
+                new IllegalArgumentException("모바일 기기를 조회 할수 없습니다.")
+        );
+
+        String resultTOTP = TimeBasedOTP.generateTOTP(device.getUuid(), steps, "8", CryptoType.HmacSHA512.toString());
         String expectedTOTP = dto.getExpectedTOTP();
 
-        log.info(resultTOTP + " : " + expectedTOTP);
-
-        return resultTOTP.equals(expectedTOTP) ? true : false;
+        return resultTOTP.equals(expectedTOTP);
     }
 }

--- a/src/main/java/dev/riyenas/osam/service/TimeBasedOTPService.java
+++ b/src/main/java/dev/riyenas/osam/service/TimeBasedOTPService.java
@@ -2,6 +2,7 @@ package dev.riyenas.osam.service;
 
 import dev.riyenas.osam.domain.auth.CryptoType;
 import dev.riyenas.osam.domain.auth.TimeBasedOTP;
+import dev.riyenas.osam.web.dto.iot.TOTPValidRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -11,15 +12,13 @@ import java.util.Calendar;
 @Log4j2
 @Service
 @RequiredArgsConstructor
-public class TimeBasedOTPAuthService {
+public class TimeBasedOTPService {
 
     public String generateByCurrentTime(String seed) {
 
         Calendar time = Calendar.getInstance();
 
         String steps = TimeBasedOTP.calcSteps(time.getTimeInMillis() / 1000, 0L, 10L);
-
-        log.info(time.getTime().toString());
 
         return TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512.toString());
     }
@@ -29,5 +28,17 @@ public class TimeBasedOTPAuthService {
         String steps = TimeBasedOTP.calcSteps(timeInMillis / 1000, 0L, 10L);
 
         return TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512.toString());
+    }
+
+    public Boolean isValidTimeBasedOtp(TOTPValidRequestDto dto) {
+
+        String steps = TimeBasedOTP.calcSteps(dto.getTimeInMillis() / 1000, 0L, 10L);
+
+        String resultTOTP = TimeBasedOTP.generateTOTP(dto.getSeed(), steps, "8", CryptoType.HmacSHA512.toString());
+        String expectedTOTP = dto.getExpectedTOTP();
+
+        log.info(resultTOTP + " : " + expectedTOTP);
+
+        return resultTOTP.equals(expectedTOTP) ? true : false;
     }
 }

--- a/src/main/java/dev/riyenas/osam/web/APITimeBasedOTPAuthController.java
+++ b/src/main/java/dev/riyenas/osam/web/APITimeBasedOTPAuthController.java
@@ -1,6 +1,7 @@
 package dev.riyenas.osam.web;
 
-import dev.riyenas.osam.service.TimeBasedOTPAuthService;
+import dev.riyenas.osam.service.TimeBasedOTPService;
+import dev.riyenas.osam.web.dto.iot.TOTPValidRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.web.bind.annotation.*;
@@ -8,18 +9,23 @@ import org.springframework.web.bind.annotation.*;
 @Log4j2
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/auth/totp/")
+@RequestMapping("/api/totp/")
 public class APITimeBasedOTPAuthController {
 
-    private final TimeBasedOTPAuthService timeBasedOTPAuthService;
+    private final TimeBasedOTPService timeBasedOTPService;
 
     @GetMapping("generate")
     public String generate(@RequestParam String seed, @RequestParam Long timeInMillis) {
-        return timeBasedOTPAuthService.generateBySeedAndTimeInMills(seed, timeInMillis);
+        return timeBasedOTPService.generateBySeedAndTimeInMills(seed, timeInMillis);
     }
 
     @GetMapping("generate/seed/{seed}")
     public String generate(@PathVariable String seed) {
-        return timeBasedOTPAuthService.generateByCurrentTime(seed);
+        return timeBasedOTPService.generateByCurrentTime(seed);
+    }
+
+    @PostMapping("valid")
+    public Boolean valid(@RequestBody TOTPValidRequestDto dto) {
+        return timeBasedOTPService.isValidTimeBasedOtp(dto);
     }
 }

--- a/src/main/java/dev/riyenas/osam/web/dto/iot/TOTPValidRequestDto.java
+++ b/src/main/java/dev/riyenas/osam/web/dto/iot/TOTPValidRequestDto.java
@@ -1,0 +1,20 @@
+package dev.riyenas.osam.web.dto.iot;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TOTPValidRequestDto {
+    private String expectedTOTP;
+    private Long timeInMillis;
+    private String seed;
+
+    @Builder
+    public TOTPValidRequestDto(String expectedTOTP, Long timeInMillis, String seed) {
+        this.expectedTOTP = expectedTOTP;
+        this.timeInMillis = timeInMillis;
+        this.seed = seed;
+    }
+}

--- a/src/main/java/dev/riyenas/osam/web/dto/iot/TOTPValidRequestDto.java
+++ b/src/main/java/dev/riyenas/osam/web/dto/iot/TOTPValidRequestDto.java
@@ -9,12 +9,12 @@ import lombok.NoArgsConstructor;
 public class TOTPValidRequestDto {
     private String expectedTOTP;
     private Long timeInMillis;
-    private String seed;
+    private Long deviceId;
 
     @Builder
-    public TOTPValidRequestDto(String expectedTOTP, Long timeInMillis, String seed) {
+    public TOTPValidRequestDto(String expectedTOTP, Long timeInMillis, Long deviceId) {
         this.expectedTOTP = expectedTOTP;
         this.timeInMillis = timeInMillis;
-        this.seed = seed;
+        this.deviceId = deviceId;
     }
 }

--- a/src/test/java/dev/riyenas/osam/totp/TimeBasedOTPTest.java
+++ b/src/test/java/dev/riyenas/osam/totp/TimeBasedOTPTest.java
@@ -1,28 +1,45 @@
 package dev.riyenas.osam.totp;
 
+import dev.riyenas.osam.domain.admin.AdminRepository;
 import dev.riyenas.osam.domain.auth.CryptoType;
 import dev.riyenas.osam.domain.auth.TimeBasedOTP;
+import dev.riyenas.osam.domain.device.Device;
+import dev.riyenas.osam.domain.device.DeviceRepository;
+import dev.riyenas.osam.domain.soldier.SoldierRepository;
 import dev.riyenas.osam.service.TimeBasedOTPService;
 import dev.riyenas.osam.web.dto.iot.TOTPValidRequestDto;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Calendar;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(properties = "classpath:application.yml")
 public class TimeBasedOTPTest {
     private static final Logger log = LoggerFactory.getLogger(TimeBasedOTPTest.class);
 
     @Autowired
     private TimeBasedOTPService timeBasedOTPService;
+
+    @Autowired
+    private DeviceRepository deviceRepository;
+
+    private String seed;
+
+    @Before
+    public void before() {
+        seed = deviceRepository.save(Device.builder().build()).getUuid();
+    }
 
     @Test
     public void createTimeBasedOTP() {
@@ -42,10 +59,15 @@ public class TimeBasedOTPTest {
 
     @Test
     public void isValidTimeBasedOtp() {
+        Long timeInMillis = 1602338274597L; //Sat Oct 10 2020 22:57:54
+
+        String steps = TimeBasedOTP.calcSteps(timeInMillis / 1000, 0L, 10L);
+        String timeBasedOTP = TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512.toString());
+
         TOTPValidRequestDto dto = TOTPValidRequestDto.builder()
-                .seed("0123456789012345678901234567890123456789")
-                .timeInMillis(1602338274597L)   //Sat Oct 10 2020 22:57:54
-                .expectedTOTP("41007144")
+                .deviceId(1L)
+                .timeInMillis(timeInMillis)
+                .expectedTOTP(timeBasedOTP)
                 .build();
 
         Assertions.assertTrue(timeBasedOTPService.isValidTimeBasedOtp(dto));

--- a/src/test/java/dev/riyenas/osam/totp/TimeBasedOTPTest.java
+++ b/src/test/java/dev/riyenas/osam/totp/TimeBasedOTPTest.java
@@ -2,25 +2,34 @@ package dev.riyenas.osam.totp;
 
 import dev.riyenas.osam.domain.auth.CryptoType;
 import dev.riyenas.osam.domain.auth.TimeBasedOTP;
+import dev.riyenas.osam.service.TimeBasedOTPService;
+import dev.riyenas.osam.web.dto.iot.TOTPValidRequestDto;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Calendar;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class TimeBasedOTPTest {
     private static final Logger log = LoggerFactory.getLogger(TimeBasedOTPTest.class);
 
+    @Autowired
+    private TimeBasedOTPService timeBasedOTPService;
+
     @Test
     public void createTimeBasedOTP() {
         String seed = "0123456789012345678901234567890123456789";
-        long T0 = 0;
-        long X = 10;
-        long testTime = 100;
+        Long T0 = 0L;
+        Long X = 10L;
+        Long testTime = 100L;
 
         String stepsA = TimeBasedOTP.calcSteps(testTime, T0, X);
         String timeBasedOTPA = TimeBasedOTP.generateTOTP(seed, stepsA, "8", CryptoType.HmacSHA512.toString());
@@ -29,5 +38,16 @@ public class TimeBasedOTPTest {
         String timeBasedOTPB = TimeBasedOTP.generateTOTP(seed, stepsB, "8", CryptoType.HmacSHA512.toString());
 
         Assertions.assertEquals(timeBasedOTPA, timeBasedOTPB);
+    }
+
+    @Test
+    public void isValidTimeBasedOtp() {
+        TOTPValidRequestDto dto = TOTPValidRequestDto.builder()
+                .seed("0123456789012345678901234567890123456789")
+                .timeInMillis(1602338274597L)   //Sat Oct 10 2020 22:57:54
+                .expectedTOTP("41007144")
+                .build();
+
+        Assertions.assertTrue(timeBasedOTPService.isValidTimeBasedOtp(dto));
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,32 @@
+server:
+  port: 8080
+  compression:
+    enabled: true
+
+spring:
+  jpa:
+    database: h2
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+      ddl-auto: create-drop
+    show-sql: true
+
+  datasource:
+    initialization-mode: never
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+    sql-script-encoding: UTF-8
+
+  h2:
+    console:
+      enabled: true
+      path: /db
+      settings:
+        web-allow-others: true
+
+logging:
+  config: classpath:log4j2.yml


### PR DESCRIPTION
* 라즈베리파이에서 QR코드를 스캔할때의 시간과 TOTP 값, seed값을 서버로 전송한다.
* 서버에서는 seed값과 Time-based값으로 TOTP값을 생성하고 라즈베리파이에서 받은 TOTP값과 비교한다.

@ckswjd99 찬정님 #20 이슈 확인하고 여기에 코멘트 부탁드립니다~

Resolves #20