### PR TITLE
ENH : SignUpCode를 이용하여 병사정보 불러오기

### DIFF
--- a/src/main/java/dev/riyenas/osam/domain/soldier/SoldierCustomRepository.java
+++ b/src/main/java/dev/riyenas/osam/domain/soldier/SoldierCustomRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 public interface SoldierCustomRepository {
     Optional<Soldier> findByServiceNumber(String serviceNumber);
     List<Soldier> findByAdminServiceNumber(String adminServiceNumber);
+    List<Soldier> findByAdminSignUpCode(String signUpCode);
 }

--- a/src/main/java/dev/riyenas/osam/domain/soldier/SoldierRepositoryImpl.java
+++ b/src/main/java/dev/riyenas/osam/domain/soldier/SoldierRepositoryImpl.java
@@ -30,5 +30,14 @@ public class SoldierRepositoryImpl extends QuerydslRepositorySupport implements 
                 .fetch();
     }
 
+    @Override
+    public List<Soldier> findByAdminSignUpCode(String signUpCode) {
+        final QSoldier soldier = QSoldier.soldier;
+
+        return from(soldier)
+                .where(soldier.admin.signUpCode.eq(signUpCode))
+                .fetch();
+    }
+
 
 }

--- a/src/main/java/dev/riyenas/osam/service/SoldierService.java
+++ b/src/main/java/dev/riyenas/osam/service/SoldierService.java
@@ -65,6 +65,18 @@ public class SoldierService {
     }
 
     @Transactional(readOnly = true)
+    public List<SoldierDeviceResponseDto> findBySignUpCode(String signUpCode) {
+        List<SoldierDeviceResponseDto> dtos = new ArrayList<>();
+        List<Soldier> soldiers = Optional.ofNullable(soldierRepository.findByAdminSignUpCode(signUpCode))
+                .filter(list -> !list.isEmpty())
+                .orElseThrow(() ->
+                        new IllegalArgumentException("해당 관리자의 회원가입 코드를 찾을수 없습니다.")
+                );
+
+        return getSoldierDeviceResponseDtos(soldiers, dtos);
+    }
+
+    @Transactional(readOnly = true)
     public List<SoldierDeviceResponseDto> findAll() {
         List<SoldierDeviceResponseDto> dtos = new ArrayList<>();
         List<Soldier> soldiers = Optional.ofNullable(soldierRepository.findAll())

--- a/src/main/java/dev/riyenas/osam/web/APIDeviceReturnController.java
+++ b/src/main/java/dev/riyenas/osam/web/APIDeviceReturnController.java
@@ -42,6 +42,11 @@ public class APIDeviceReturnController {
         return soldierService.findByAdminServiceNumber(adminServiceNumber);
     }
 
+    @GetMapping("find/admin/signUpCode/{signUpCode}")
+    public List<SoldierDeviceResponseDto> findBySignUpCode(@PathVariable String signUpCode) {
+        return soldierService.findBySignUpCode(signUpCode);
+    }
+
     @PostMapping(value = "device/log/create", produces = MediaType.IMAGE_JPEG_VALUE)
     public @ResponseBody byte[] returnLogCreate(@RequestBody DeviceReturnRequestDto dto) throws ParseException {
         return returnLogService.saveReturnLog(dto);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,13 +1,15 @@
 -- Admin
-INSERT INTO admin(id, serviceNumber, password, name, signUpCode) VALUES (1, '20-123456', '1234', '중대장', '88888888');
+INSERT INTO admin(id, serviceNumber, password, name, signUpCode) VALUES (1, '20-123456', '1234', '중대장1', '88888888');
+INSERT INTO admin(id, serviceNumber, password, name, signUpCode) VALUES (2, '20-654321', '4321', '중대장2', '99999999');
 
 -- Rule
 INSERT INTO rule(id, dispensingTime, returnTime, admin_id) VALUES (1, PARSEDATETIME('17:30', 'HH:mm'), PARSEDATETIME('20:50', 'HH:mm'), 1);
+INSERT INTO rule(id, dispensingTime, returnTime, admin_id) VALUES (2, PARSEDATETIME('17:30', 'HH:mm'), PARSEDATETIME('20:50', 'HH:mm'), 2);
 
 -- Soldier
 INSERT INTO soldier(id, serviceNumber, name, rank, unit, admin_id) VALUES (1, '11-111111', '강동민', '병장', '육군', 1);
 INSERT INTO soldier(id, serviceNumber, name, rank, unit, admin_id) VALUES (2, '22-222222', '이진휘', '병장', '육군', 1);
-INSERT INTO soldier(id, serviceNumber, name, rank, unit, admin_id) VALUES (3, '33-333333', '박찬정', '병장', '육군', 1);
+INSERT INTO soldier(id, serviceNumber, name, rank, unit, admin_id) VALUES (3, '33-333333', '박찬정', '병장', '육군', 2);
 
 -- Device
 INSERT INTO device(id, serialNumber, type, manufacturer, phoneNumber, uuid, soldier_id) VALUES (1, 'S/N11111', 'PHONE' , 'Samsung', '010-1111-1111', '0083064714901929041789047456568262994694', 1);


### PR DESCRIPTION
* SignUpCode로 관리자에 포함되어 있는 병사 정보 모두를 불러올 수 있는 API
* 테스트 데이터로 중대장1(88888888), 중대장2(99999999) 로 저장 (괄호안에 값은 회원가입 코드)

Resolves #56