### PR TITLE
BUG : Time-based OTP값이 앱과 서버에서 다르게 생성되는 오류

### DIFF
--- a/src/main/java/dev/riyenas/osam/domain/auth/CryptoType.java
+++ b/src/main/java/dev/riyenas/osam/domain/auth/CryptoType.java
@@ -2,8 +2,8 @@ package dev.riyenas.osam.domain.auth;
 
 public enum CryptoType {
     HmacSHA1("HmacSHA1"),
-    HmacSHA256("HmacSHA1"),
-    HmacSHA512("HmacSHA1");
+    HmacSHA256("HmacSHA256"),
+    HmacSHA512("HMacSHA512");
 
     CryptoType(String crypto) {
         this.crypto = crypto;

--- a/src/main/java/dev/riyenas/osam/domain/auth/TimeBasedOTP.java
+++ b/src/main/java/dev/riyenas/osam/domain/auth/TimeBasedOTP.java
@@ -50,18 +50,18 @@ public class TimeBasedOTP {
     }
 
     public static String generateTOTP(String key, String time, String returnDigits) {
-        return generateTOTP(key, time, returnDigits, CryptoType.HmacSHA1.toString());
+        return generateTOTP(key, time, returnDigits, CryptoType.HmacSHA1);
     }
 
     public static String generateTOTP256(String key, String time, String returnDigits) {
-        return generateTOTP(key, time, returnDigits, CryptoType.HmacSHA256.toString());
+        return generateTOTP(key, time, returnDigits, CryptoType.HmacSHA256);
     }
 
     public static String generateTOTP512(String key, String time, String returnDigits) {
-        return generateTOTP(key, time, returnDigits, CryptoType.HmacSHA512.toString());
+        return generateTOTP(key, time, returnDigits, CryptoType.HmacSHA512);
     }
 
-    public static String generateTOTP(String key, String time, String returnDigits, String crypto) {
+    public static String generateTOTP(String key, String time, String returnDigits, CryptoType type) {
         int codeDigits = Integer.decode(returnDigits).intValue();
         String result = null;
         byte[] hash;
@@ -73,7 +73,7 @@ public class TimeBasedOTP {
         byte[] msg = hexStrToBytes(time);
         byte[] k = hexStrToBytes(key);
 
-        hash = hmac_sha1(crypto, k, msg);
+        hash = hmac_sha1(type.toString(), k, msg);
 
         int offset = hash[hash.length - 1] & 0xf;
 

--- a/src/main/java/dev/riyenas/osam/service/TimeBasedOTPService.java
+++ b/src/main/java/dev/riyenas/osam/service/TimeBasedOTPService.java
@@ -33,7 +33,7 @@ public class TimeBasedOTPService {
 
         String steps = TimeBasedOTP.calcSteps(time.getTimeInMillis() / 1000, 0L, 10L);
 
-        return TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512.toString());
+        return TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512);
     }
 
     public String generateByCurrentTime(Long deviceId) {
@@ -46,14 +46,14 @@ public class TimeBasedOTPService {
 
         String steps = TimeBasedOTP.calcSteps(time.getTimeInMillis() / 1000, 0L, 10L);
 
-        return TimeBasedOTP.generateTOTP(device.getUuid(), steps, "8", CryptoType.HmacSHA512.toString());
+        return TimeBasedOTP.generateTOTP(device.getUuid(), steps, "8", CryptoType.HmacSHA512);
     }
 
     public String generateBySeedAndTimeInMills(String seed, Long timeInMillis) {
 
         String steps = TimeBasedOTP.calcSteps(timeInMillis / 1000, 0L, 10L);
 
-        return TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512.toString());
+        return TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512);
     }
 
     public Boolean isValidTimeBasedOtp(TOTPValidRequestDto dto) {
@@ -63,7 +63,7 @@ public class TimeBasedOTPService {
         );
 
         String steps = TimeBasedOTP.calcSteps(dto.getTimeInMillis() / 1000, 0L, 10L);
-        String resultTOTP = TimeBasedOTP.generateTOTP(device.getUuid(), steps, "8", CryptoType.HmacSHA512.toString());
+        String resultTOTP = TimeBasedOTP.generateTOTP(device.getUuid(), steps, "8", CryptoType.HmacSHA512);
 
         String expectedTOTP = dto.getExpectedTOTP();
 
@@ -80,7 +80,7 @@ public class TimeBasedOTPService {
         Calendar time = Calendar.getInstance();
 
         String steps = TimeBasedOTP.calcSteps(time.getTimeInMillis() / 1000, 0L, 10L);
-        String totp = TimeBasedOTP.generateTOTP(device.getUuid(), steps, "8", CryptoType.HmacSHA512.toString());
+        String totp = TimeBasedOTP.generateTOTP(device.getUuid(), steps, "8", CryptoType.HmacSHA512);
 
         QRCodeRequestDto dto = QRCodeRequestDto.builder()
                 .deviceId(deviceId)

--- a/src/test/java/dev/riyenas/osam/totp/TimeBasedOTPTest.java
+++ b/src/test/java/dev/riyenas/osam/totp/TimeBasedOTPTest.java
@@ -44,10 +44,10 @@ public class TimeBasedOTPTest {
         Long testTime = 100L;
 
         String stepsA = TimeBasedOTP.calcSteps(testTime, T0, X);
-        String timeBasedOTPA = TimeBasedOTP.generateTOTP(seed, stepsA, "8", CryptoType.HmacSHA512.toString());
+        String timeBasedOTPA = TimeBasedOTP.generateTOTP(seed, stepsA, "8", CryptoType.HmacSHA512);
 
         String stepsB = TimeBasedOTP.calcSteps(testTime + 9, T0, X);
-        String timeBasedOTPB = TimeBasedOTP.generateTOTP(seed, stepsB, "8", CryptoType.HmacSHA512.toString());
+        String timeBasedOTPB = TimeBasedOTP.generateTOTP(seed, stepsB, "8", CryptoType.HmacSHA512);
 
         Assertions.assertEquals(timeBasedOTPA, timeBasedOTPB);
     }
@@ -58,7 +58,7 @@ public class TimeBasedOTPTest {
         Long timeInMillis = 1602338274597L; //Sat Oct 10 2020 22:57:54
 
         String steps = TimeBasedOTP.calcSteps(timeInMillis / 1000, 0L, 10L);
-        String timeBasedOTP = TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512.toString());
+        String timeBasedOTP = TimeBasedOTP.generateTOTP(seed, steps, "8", CryptoType.HmacSHA512);
 
         TOTPValidRequestDto dto = TOTPValidRequestDto.builder()
                 .deviceId(1L)


### PR DESCRIPTION
* 서버측 암호화방식을 담아둔 Enum에서 SHA1, SHA256, SHA512 모두 값이 SHA1로 고정되어 있는 오류 발생
* 따라서 앱에서는 정상적으로 SHA512로 TOTP를 생성했지만 서버에서 SHA1로 생성했기 떄문에 서로 값이 다른 오류 발생

Resolves #62